### PR TITLE
Deprecate order:expiration_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- Deprecated `order:expiration_date` in favor of `expires`
+
 ## [v1.0.0] - 2022-08-18
 
 - Initial release of the STAC Order Extension.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The main field describing the order status
 
 The [timestamps extension](https://github.com/stac-extensions/timestamps/) and the fields
 [`created` and `updated` from common metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#date-and-time)
-can be useful additions to the Item properties or Collection:
+can be useful addition, usually used in the Item Properties and Collections, sometimes also in the Assets:
 
 - Set `order:date` once the status switches to `ordered` (i.e. when the user submits the order).
 - Set `created` once the metadata files gets created, usually when the status is `ordered` or `shipping`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The fields in the table below can be used in these parts of STAC documents:
 | order:status          | string   | **REQUIRED**. Describe the status of the ordering. One of the value listed [here](#orderstatus) |
 | order:id              | string   | Identifier of the order                                                                |
 | order:date            | datetime | Indicates the order time                                                                        |
-| order:expiration_date | datetime | Indicates the validity time of the order.                                                       |
+| order:expiration_date | datetime | **DEPRECATED.** Indicates the validity time of the order. Use [`expires` from the timestamps extension](https://github.com/stac-extensions/timestamps/) instead. |
 
 These fields have different meaning depending on where they are used.
 When used as an Item properties or top-level Collection field, they refer to an order of all data referenced in the Item or Collection, 
@@ -65,10 +65,10 @@ When used in an Asset Object, the order refer to the particular data asset linke
 
 The main field describing the order status
 
-- `orderable`: The item or asset is orderable via the provider scenario
+- `orderable`: The item or asset is orderable via the provider scenario.
 - `ordered`: The item or asset is ordered and the provider is preparing to make it available.
 - `pending`: The item or asset is ordered but wait for an activation before being able for shipping.
-- `shipping` The item or asset order are being processed by the provider to provide you with the asset(s).
+- `shipping`: The item or asset order are being processed by the provider to provide you with the asset(s).
 - `succeeded`: The provider has delivered your order and asset(s) are available.
 - `failed`: The provider is not able to deliver the order.
 - `canceled` The order has been canceled.

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -2,7 +2,8 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/order/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/order/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/timestamps/v1.0.0/schema.json"
   ],
   "type": "Collection",
   "id": "collection",
@@ -32,7 +33,7 @@
   "order:status": "succeeded",
   "order:id": "123e4567-e89b-12d3-a456-426614174000",
   "order:date": "2020-12-12T22:38:32Z",
-  "order:expiration_date": "2020-12-19T22:38:32Z",
+  "expires": "2020-12-19T22:38:32Z",
   "assets": {
     "example": {
       "href": "https://example.com/examples/file.xyz",

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,7 +1,8 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/order/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/order/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/timestamps/v1.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "item",
@@ -39,11 +40,14 @@
     ]
   },
   "properties": {
-    "datetime": "2020-12-11T22:38:32Z",
     "order:status": "succeeded",
     "order:id": "123e4567-e89b-12d3-a456-426614174000",
-    "order:date": "2020-12-12T22:38:32Z",
-    "order:expiration_date": "2020-12-19T22:38:32Z"
+    "datetime": "2017-01-01T05:12:55Z",
+    "order:date": "2020-12-12T20:01:55Z",
+    "created": "2020-12-12T20:32:22Z",
+    "updated": "2020-12-12T22:38:32Z",
+    "published": "2020-12-12T22:38:32Z",
+    "expires": "2020-12-19T22:38:32Z"
   },
   "links": [
     {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -183,7 +183,8 @@
         },
         "order:expiration_date": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "deprecated": true
         }
       },
       "patternProperties": {


### PR DESCRIPTION
Deprecate `order:expiration_date` and recommend to use the more general `expires` instead.
We could release this with the other changes in 1.1 and then remove it whenever we come towards 2.0.
I'd also be happy to remove it directly, but don't want to make others implementations invalid...