### PR TITLE
Add enum to status field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added enum to `order:status` as defined in the README before.
+
 ## [v1.1.0] - 2023-01-06
 
 ### Changed

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -172,7 +172,16 @@
       "type": "object",
       "properties": {
         "order:status": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "orderable",
+            "ordered",
+            "pending",
+            "shipping",
+            "succeeded",
+            "failed",
+            "canceled"
+          ]
         },
         "order:id": {
           "type": "string"


### PR DESCRIPTION
Closes #16 

The field descrption explicity says "One of the value listed [here](https://github.com/stac-extensions/order#orderstatus)", so it seems it's meant to be an enum.